### PR TITLE
sidebar_image not shown on pages

### DIFF
--- a/header.php
+++ b/header.php
@@ -51,10 +51,10 @@
 					color: #F7F2CB;
 				}
 		</style>
-		<?php if (article_custom_field('sidebar_image')): ?>
+		<?php if (($img = article_custom_field('sidebar_image')) || ($img = page_custom_field('sidebar_image'))): ?>
 			<style>
 				.sidebar {
-					background: url("<?php echo article_custom_field('sidebar_image'); ?>") center no-repeat;
+					background: url("<?php echo $img; ?>") center no-repeat;
 					background-size: cover;
 					color: white;
 					text-shadow: 0px 1px 5px rgba(0,0,0,0.3);


### PR DESCRIPTION
On pages the sidbar_image is not shown, when set in the backend, as noted in issue #2.

`header.php` checks only for sidebar_images with the `article_custom_field()` function. However for pages this returns nothing, pages seem to need the `page_custom_field()` for that. I added both to the `header.php`.

I'm not sure if this is the best way to solve this problem, since I'm new to Anchor. However it seemed to worked that way. :) 

Cheers,
Jona
